### PR TITLE
Abstract the Tile Store interface so that different tile stores, othe…

### DIFF
--- a/elt/src/main/java/com/leidoslabs/holeshot/elt/ELT.java
+++ b/elt/src/main/java/com/leidoslabs/holeshot/elt/ELT.java
@@ -636,7 +636,7 @@ public class ELT implements Runnable {
 
 	/**
 	 * Retrieves the newest ELTFrame for the given appId
-	 * @param appID The context for the last loaded image.
+	 * @param appId The context for the last loaded image.
 	 * @return The newest ELTFrame for the given appId.
 	 */
 	public ELTFrame getLastLoadedAppImage(String appId) {

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<json.version>20180130</json.version>
 		<jsonpath.version>2.4.0</jsonpath.version>
 		<jts.version>1.16.1</jts.version>
-		<junit.version>4.12</junit.version>
+		<junit.version>4.13</junit.version>
 		<jwt.version>3.8.0</jwt.version>
 		<jwks.version>0.8.1</jwks.version>
 		<leidosimaging.version>0.0.1-SNAPSHOT</leidosimaging.version>
@@ -73,11 +73,11 @@
 		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
 		<maven-download-plugin.version>1.2.1</maven-download-plugin.version>
 		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-		<maven-resources-plugin.version>2.7</maven-resources-plugin.version>
+		<maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
 		<mavencompilerplugin.version>3.3</mavencompilerplugin.version>
 		<mavenjavadocplugin.version>3.1.1</mavenjavadocplugin.version>
 		<mavenshadeplugin.version>3.2.1</mavenshadeplugin.version>
-		<mavensurefireplugin.version>2.20</mavensurefireplugin.version>
+		<mavensurefireplugin.version>2.22.1</mavensurefireplugin.version>
 		<mockito.version>2.0.2-beta</mockito.version>
 		<nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -1087,16 +1087,6 @@
 					</repository -->
 
 				<repository>
-					<id>springsource-release</id>
-					<name>springsource-release</name>
-					<url>http://repository.springsource.com/maven/bundles/release</url>
-				</repository>
-				<repository>
-					<id>springsource-external</id>
-					<name>springsource-external</name>
-					<url>http://repository.springsource.com/maven/bundles/external</url>
-				</repository>
-				<repository>
 					<id>maven-eclipse-repo</id>
 					<name>maven-eclipse-repo</name>
 					<url>http://maven-eclipse.github.io/maven</url>
@@ -1127,11 +1117,6 @@
 					<url>https://repository.apache.org/content/repositories/snapshots/</url>
 				</repository>
 				<repository>
-					<id>boundless</id>
-					<name>boundless</name>
-					<url>http://repo.boundlessgeo.com/main/</url>
-				</repository>
-				<repository>
 					<id>osgeo</id>
 					<name>osgeo</name>
 					<url>http://download.osgeo.org/webdav/geotools/</url>
@@ -1153,16 +1138,6 @@
 				</repository>
 			</repositories>
 			<pluginRepositories>
-				<pluginRepository>
-					<id>springsource-release</id>
-					<name>springsource-release</name>
-					<url>http://pluginRepository.springsource.com/maven/bundles/release</url>
-				</pluginRepository>
-				<pluginRepository>
-					<id>springsource-external</id>
-					<name>springsource-external</name>
-					<url>http://pluginRepository.springsource.com/maven/bundles/external</url>
-				</pluginRepository>
 				<pluginRepository>
 					<id>maven-eclipse-repo</id>
 					<name>maven-eclipse-repo</name>
@@ -1192,11 +1167,6 @@
 					<id>apache-snapshots</id>
 					<name>apache-snapshots</name>
 					<url>https://pluginRepository.apache.org/content/repositories/snapshots/</url>
-				</pluginRepository>
-				<pluginRepository>
-					<id>boundless</id>
-					<name>boundless</name>
-					<url>http://repo.boundlessgeo.com/main/</url>
 				</pluginRepository>
 				<pluginRepository>
 					<id>osgeo</id>

--- a/tile-service/pom.xml
+++ b/tile-service/pom.xml
@@ -132,7 +132,18 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>com.hierynomus</groupId>
+            <artifactId>smbj</artifactId>
+            <version>0.10.0</version>
+        </dependency>
+		<dependency>
+			<groupId>io.findify</groupId>
+			<artifactId>s3mock_2.13</artifactId>
+			<version>0.2.6</version>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
 	<build>
 		<plugins>
 			<plugin>

--- a/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/mrf/MRFTileRef.java
+++ b/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/mrf/MRFTileRef.java
@@ -18,7 +18,7 @@ package com.leidoslabs.holeshot.tileserver.mrf;
 import com.leidoslabs.holeshot.elt.tileserver.AbstractTileRef;
 
 /**
- * TileRef with object size incorportated
+ * TileRef with object size incorporated
  */
 public class MRFTileRef extends AbstractTileRef<MRFTileRef> {
 	private final long objectSize;

--- a/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/mrf/S3ObjectsIterator.java
+++ b/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/mrf/S3ObjectsIterator.java
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
@@ -34,7 +33,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
  * Utility class for listing objects from s3 buckets as an iterator.
  * @param <T>
  */
-public class ListObjectsIterator <T> implements Iterator<T> {
+public class S3ObjectsIterator<T> implements Iterator<T> {
    private static final int MAX_KEYS_PER_READ=1000;
    private ListObjectsV2Result result;
    private final ListObjectsV2Request request;
@@ -47,8 +46,8 @@ public class ListObjectsIterator <T> implements Iterator<T> {
     * @param request S3 API List objects request
     * @param collectionMethod 
     */
-   public ListObjectsIterator(ListObjectsV2Request request, Function<ListObjectsV2Result, List<T>> collectionMethod ) {
-      s3Client = AmazonS3ClientBuilder.defaultClient();
+   public S3ObjectsIterator(ListObjectsV2Request request, Function<ListObjectsV2Result, List<T>> collectionMethod, AmazonS3 client ) {
+      s3Client = client;
       this.collectionMethod = collectionMethod;
       this.request = request;
       this.result = null;
@@ -69,12 +68,12 @@ public class ListObjectsIterator <T> implements Iterator<T> {
     * @param prefix
     * @return
     */
-   public static ListObjectsIterator<String> listPrefixes(String bucket, String prefix) {
-      return new ListObjectsIterator<String>(new ListObjectsV2Request()
+   public static S3ObjectsIterator<String> listPrefixes(String bucket, String prefix, AmazonS3 s3Client) {
+      return new S3ObjectsIterator<String>(new ListObjectsV2Request()
             .withBucketName(bucket)
             .withDelimiter("/")
             .withPrefix(prefix)
-            .withMaxKeys(MAX_KEYS_PER_READ), ListObjectsV2Result::getCommonPrefixes);
+            .withMaxKeys(MAX_KEYS_PER_READ), ListObjectsV2Result::getCommonPrefixes, s3Client);
    }
    
    /**
@@ -83,11 +82,11 @@ public class ListObjectsIterator <T> implements Iterator<T> {
     * @param prefix
     * @return
     */
-   public static ListObjectsIterator<S3ObjectSummary> listObjects(String bucket, String prefix) {
-      return new ListObjectsIterator<S3ObjectSummary>(new ListObjectsV2Request()
+   public static S3ObjectsIterator<S3ObjectSummary> listObjects(String bucket, String prefix, AmazonS3 s3Client) {
+      return new S3ObjectsIterator<S3ObjectSummary>(new ListObjectsV2Request()
             .withBucketName(bucket)
             .withPrefix(prefix)
-            .withMaxKeys(MAX_KEYS_PER_READ), ListObjectsV2Result::getObjectSummaries);
+            .withMaxKeys(MAX_KEYS_PER_READ), ListObjectsV2Result::getObjectSummaries, s3Client);
    }
 
    /**

--- a/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/service/AbstractTileStoreBase.java
+++ b/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/service/AbstractTileStoreBase.java
@@ -1,0 +1,96 @@
+package com.leidoslabs.holeshot.tileserver.service;
+
+import com.leidoslabs.holeshot.tileserver.cache.ByteBufferCodec;
+import com.leidoslabs.holeshot.tileserver.cache.RedisCache;
+import com.leidoslabs.holeshot.tileserver.service.pool.TransferBufferPool;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Abstract class intended to be extended by actual implementations of TileStore. Contains
+ * common constants and functions for handling the Redis cache
+ */
+public abstract class AbstractTileStoreBase implements ITileStore{
+
+    private static final XLogger logger = XLoggerFactory.getXLogger(AbstractTileStoreBase.class);
+
+    protected final static int TRANSFER_POOL_BUFFER_SIZE_IN_BYTES = 1024 * 8;
+    protected final static int MAX_CACHED_TILE_SIZE_IN_BYTES = 1000000;
+
+    protected TransferBufferPool cacheTransferBufferPool;
+
+    /**
+     * Write to outputstream from cache using a transfer buffer,
+     * @param wholeKey
+     * @param out
+     * @return
+     * @throws Exception
+     */
+    protected boolean writeFromCache(String wholeKey, OutputStream out) throws Exception {
+        logger.entry();
+        boolean success = false;
+        ByteBuffer buffer = cacheGet(wholeKey);
+        if (buffer != null) {
+            if (buffer.hasArray()) {
+                out.write(buffer.array(), buffer.position(), buffer.remaining());
+            } else {
+                byte[] transferBuffer = null;
+                try {
+                    transferBuffer = cacheTransferBufferPool.borrowObject();
+                    int imageSize = buffer.remaining();
+                    buffer.get(transferBuffer, 0, imageSize);
+                    out.write(transferBuffer, 0, imageSize);
+                } finally {
+                    cacheTransferBufferPool.returnObject(transferBuffer);
+                }
+            }
+            success = true;
+        }
+        logger.exit();
+        return success;
+    }
+
+
+    /**
+     * Add file to RedisCache under key
+     * @param wholeKey
+     * @param file
+     */
+    protected void cacheAdd(String wholeKey, ByteBuffer file) {
+        logger.entry();
+        if (RedisCache.getInstance().isAvailable()) {
+            RedisClient client = RedisCache.getInstance().getRedis();
+            try (StatefulRedisConnection<String, ByteBuffer> connection = client.connect(new ByteBufferCodec())) {
+                RedisCommands<String, ByteBuffer> commands = connection.sync();
+                commands.set(wholeKey,  file);
+            }
+        }
+        logger.exit();
+    }
+
+    /**
+     * Retrieve object from RedisCache
+     * @param wholeKey
+     * @return
+     */
+    protected ByteBuffer cacheGet(String wholeKey) {
+        logger.entry();
+        ByteBuffer value = null;
+        if (RedisCache.getInstance().isAvailable()) {
+            RedisClient client = RedisCache.getInstance().getRedis();
+            try (StatefulRedisConnection<String, ByteBuffer> connection = client.connect(new ByteBufferCodec())) {
+                RedisCommands<String, ByteBuffer> commands = connection.sync();
+                value = commands.get(wholeKey);
+            }
+        }
+        logger.exit();
+        return value;
+    }
+
+}

--- a/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/service/ITile.java
+++ b/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/service/ITile.java
@@ -1,0 +1,11 @@
+package com.leidoslabs.holeshot.tileserver.service;
+
+/**
+ * Interface for accessing attributes of a tile.
+ */
+public interface ITile {
+
+    String getKey();
+
+    long getSize();
+}

--- a/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/service/ITileStore.java
+++ b/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/service/ITileStore.java
@@ -1,0 +1,114 @@
+package com.leidoslabs.holeshot.tileserver.service;
+
+import javax.servlet.ServletRequest;
+import javax.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.util.Iterator;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * The ITileStore interface abstracts the underlying tile store implementation from the rest
+ * of the code.
+ * <p>
+ * It refers to the concept of folders which are containers where objects are stored
+ * Implementations of this interface may consider the concept of folder differently.
+ * For example an object store, such as Amazon S3, would use the key name to
+ * recognise the folder. An SMB file store would use a hierarchical set of folders.
+ */
+public interface ITileStore {
+
+    Response getResponse(ServletRequest request, String wholeKey);
+
+    WriteFrom writeResponse(ServletRequest request, String wholeKey, OutputStream out) throws Exception;
+
+    /**
+     * Get SMB object and copy to out, and add to cache if useCache. Ensures retrieved objects are less than
+     * MAX_CACHED_TILE_SIZE_IN_BYTES
+     *
+     * @param wholeKey the key for the object to retrieve
+     * @param out      the outstream to copy the object to
+     * @param useCache true indicates that the object should be added to the cache too
+     * @throws Exception
+     */
+    void writeFromStore(String wholeKey, OutputStream out, boolean useCache) throws Exception;
+
+    /**
+     * Puts an object into the store
+     *
+     * @param objectName The name that the object should be stored as. This should be the relative
+     *                   path from the root of the store
+     * @param bis        the object that should be written
+     * @param mimeType   the mime type of the object
+     */
+    void putObject(String objectName, ByteArrayInputStream bis, String mimeType);
+
+    /**
+     * Gets an iterator for the names of all the sub folders under the path passed
+     * in. This will not include objects within the folder and will only go one level
+     * down from the parent
+     *
+     * @param parentPath the parent folder to search within
+     * @return iterator for the names of all the subfolders paths
+     */
+    Iterator<String> getSubFolders(String parentPath);
+
+    /**
+     * Gets an iterator containing all the names of sub folders that contain the string passed in. The string
+     * is contained anywhere within the path
+     *
+     * @param parentPath   the parent folder to search within
+     * @param nameContains the string that the name must contain
+     * @return iterator containing all the names of subfolders that contain the string passed in
+     */
+    Iterator<String> getSubFoldersByName(String parentPath, String nameContains);
+
+    /**
+     * Gets an iterator containing all the names of sub folders that contain the string passed in. The string
+     * is contained anywhere within the path
+     *
+     * @param parentPath   the parent folder to search within
+     * @param nameContains the string that the name must contain
+     * @return stream containing all the names of subfolders that contain the string passed in
+     */
+    Stream<String> getSubFoldersByNameAsStream(String parentPath, String nameContains);
+
+    /**
+     * Gets an iterator containing all the names of sub folders that match the regular expression
+     *
+     * @param parentPath the parent folder to search within
+     * @param regExp     the regular expression to search using
+     * @return iterator containing the names of subfolders that match the regex string
+     */
+    Iterator<String> getSubFoldersMatching(String parentPath, Pattern regExp);
+
+    /**
+     * Gets a stream containing all the names of sub folders that match the regular expression
+     *
+     * @param parentPath the parent folder to search within
+     * @param regExp     the regular expression to search using
+     * @return stream containing the names of subfolders that match the regex string
+     */
+    Stream<String> getSubFoldersMatchingAsStream(String parentPath, Pattern regExp);
+
+    /**
+     * Returns a list of the objects that are in a particular folder
+     *
+     * @param folder the folder to list the objects from
+     * @return a stream of objects that support the ITile interface
+     */
+    Stream<ITile> listObjects(String folder);
+
+    /**
+     * Returns a list of the objects that are in a particular folder
+     *
+     * @param folder          the folder to list the objects from
+     * @param objectNameRegex regexpression to be used to filter objects
+     * @return a stream of objects that support the ITile interface
+     */
+    Stream<ITile> listObjects(String folder, Pattern objectNameRegex);
+
+    enum WriteFrom {CACHE, S3}
+
+}

--- a/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/service/mrf/MRFService.java
+++ b/tile-service/src/main/java/com/leidoslabs/holeshot/tileserver/service/mrf/MRFService.java
@@ -128,7 +128,7 @@ public class MRFService {
       MRFIndexFile indexFile = mrfIndexCache.get(mrfIndexPrefix);
       if (indexFile == null) {
          final TileserverImage image = getImage(imageId, timestamp);
-         indexFile = new MRFIndexFile(image, s3Handler, region, bucket, mrfIndexPrefix);
+         indexFile = new MRFIndexFile(image, s3Handler, mrfIndexPrefix);
          mrfIndexCache.put(mrfIndexPrefix, indexFile);
       }
       return indexFile;

--- a/tile-service/src/test/java/com/leidoslabs/holeshot/tileserver/service/S3HandlerTest.java
+++ b/tile-service/src/test/java/com/leidoslabs/holeshot/tileserver/service/S3HandlerTest.java
@@ -1,0 +1,247 @@
+package com.leidoslabs.holeshot.tileserver.service;
+
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import junit.framework.TestCase;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.findify.s3mock.S3Mock;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class S3HandlerTest extends TestCase {
+
+    private S3Mock mockS3api;
+    private AmazonS3 testClient;
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+
+    @Before
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @After
+    public void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    public void setUp() throws Exception {
+        super.setUp();
+
+        //Set up the mock S3 API which will use memory to store the objects rather than the file system
+        mockS3api = new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
+        mockS3api.start();
+
+
+       /* AWS S3 client setup.
+         *  withPathStyleAccessEnabled(true) trick is required to overcome S3 default
+         *  DNS-based bucket access scheme
+         *  resulting in attempts to connect to addresses like "bucketname.localhost"
+         *  which requires specific DNS setup.
+         */
+        EndpointConfiguration endpoint = new EndpointConfiguration("http://localhost:8001", "us-west-2");
+        testClient = AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(endpoint)
+ //               .withRegion("us-west-2")
+                .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+                .build();
+
+        //Put some data in the S3mock
+        testClient.createBucket("testbucket");
+        testClient.putObject("testbucket", "tile01", "tile01 at root");
+        testClient.putObject("testbucket", "file/tile01", "tile01");
+        testClient.putObject("testbucket", "file/tile01/metadata.json", "tile01 metadata");
+        testClient.putObject("testbucket", "file/tile02", "tile02");
+        testClient.putObject("testbucket", "file/tile02/additional folder/data", "Additional folder data");
+        testClient.putObject("testbucket", "file/tile02/metadata.json", "tile02 metadata");
+        testClient.putObject("testbucket", "file/tile03", "tile03");
+        testClient.putObject("testbucket", "file/tile04/random-object", "Random object");
+        testClient.putObject("testbucket", "file2/tile05/random-object", "Random object");
+        testClient.putObject("testbucket", "file2/tile05/random-object2", "Random object 2");
+        testClient.putObject("testbucket", "file2/tile06/tile05/object", "Random object");
+        testClient.putObject("testbucket", "file2/tile06/tile05", "Random object");
+
+        ListObjectsV2Result myResults = testClient.listObjectsV2 ("testbucket");
+        assertEquals(12, myResults.getKeyCount());
+    }
+
+    public void tearDown() throws Exception {
+        mockS3api.shutdown();
+    }
+
+    public void testGetResponse() {
+    }
+
+    public void testWriteResponse() {
+    }
+
+    public void testWriteFromStore() {
+    }
+
+    public void testPutObject() {
+    }
+
+    public void testGetSubFolders() {
+        S3Handler handler = new S3Handler("testbucket", "us-east-1", 20);
+        handler.s3Client = testClient;
+
+        System.out.println("Subfolders under file/");
+        Iterator<String> childPrefixes = handler.getSubFolders("file/");
+        int folderCount = 0;
+        while (childPrefixes.hasNext()){
+            String prefix = childPrefixes.next();
+            System.out.println(prefix);
+            folderCount++;
+        }
+        assertEquals(3,folderCount);
+
+        System.out.println("Subfolders under file/tile01");
+        childPrefixes = handler.getSubFolders("file/tile01/");
+        folderCount = 0;
+        while (childPrefixes.hasNext()){
+            String prefix = childPrefixes.next();
+            System.out.println(prefix);
+            folderCount++;
+        }
+        assertEquals(0,folderCount);
+
+        System.out.println("Subfolders under file/tile02");
+        childPrefixes = handler.getSubFolders("file/tile02/");
+        folderCount = 0;
+        while (childPrefixes.hasNext()){
+            String prefix = childPrefixes.next();
+            System.out.println(prefix);
+            folderCount++;
+        }
+        assertEquals(1,folderCount);
+
+        System.out.println("Subfolders under root");
+        childPrefixes = handler.getSubFolders("");
+        folderCount = 0;
+        while (childPrefixes.hasNext()){
+            String prefix = childPrefixes.next();
+            System.out.println(prefix);
+            folderCount++;
+        }
+        assertEquals(2,folderCount);
+    }
+
+    public void testGetSubFoldersByName() {
+        S3Handler handler = new S3Handler("testbucket", "us-east-1", 20);
+        handler.s3Client = testClient;
+
+        Iterator<String> folders = handler.getSubFoldersByName("file2/", "tile06");
+        int folderCount = 0;
+        while (folders.hasNext()){
+            String folderName = folders.next();
+            System.out.println(folderName);
+            folderCount++;
+        }
+        assertEquals(1,folderCount);
+
+        folders = handler.getSubFoldersByName("file2/", "tile05");
+        folderCount = 0;
+        while (folders.hasNext()){
+            String folderName = folders.next();
+            System.out.println(folderName);
+            folderCount++;
+        }
+        assertEquals(1,folderCount);
+
+    }
+
+    public void testGetSubFoldersByNameAsStream() {
+        S3Handler handler = new S3Handler("testbucket", "us-east-1", 20);
+        handler.s3Client = testClient;
+
+        assertEquals(1,handler.getSubFoldersByNameAsStream("file2/", "tile06").count());
+
+        assertEquals(1,handler.getSubFoldersByNameAsStream("file2/", "tile05").count());
+
+    }
+    public void testListObjects() {
+
+        S3Handler handler = new S3Handler("testbucket", "us-east-1", 20);
+        handler.s3Client = testClient;
+
+        //listObjects - no filters
+        Stream<ITile> childObjects = handler.listObjects("");
+        //childObjects.forEach(o -> System.out.println(o.getKey()));
+        assertEquals(12, childObjects.count());
+
+        //listObjects in folder
+        Stream<ITile>  childObjects2 = handler.listObjects("file/");
+        assertEquals(7, childObjects2.count());
+
+        //listObjects with regex
+        Stream<ITile>  childObjects3 = handler.listObjects("", Pattern.compile("[A-Z,a-z,0-9/]*metadata.json\\b"));
+        assertEquals(2,childObjects3.count());
+
+        //listObjects in folder with regex
+        Stream<ITile>  childObjects4 = handler.listObjects("file/tile02",  Pattern.compile("[A-Z,a-z,0-9/]*metadata.json\\b"));
+        assertEquals(1,childObjects4.count());
+
+    }
+
+    public void testGetSubFoldersMatching() {
+        S3Handler handler = new S3Handler("testbucket", "us-east-1", 20);
+        handler.s3Client = testClient;
+
+        Iterator<String> folders = handler.getSubFoldersMatching("file2/tile06/", Pattern.compile(".*"));
+        int folderCount = 0;
+        while (folders.hasNext()){
+            String folderName = folders.next();
+            System.out.println(folderName);
+            folderCount++;
+        }
+        assertEquals(1,folderCount);
+
+        folders = handler.getSubFoldersMatching("file2/", Pattern.compile(".*05"));
+        folderCount = 0;
+        while (folders.hasNext()){
+            String folderName = folders.next();
+            System.out.println(folderName);
+            folderCount++;
+        }
+        assertEquals(1,folderCount);
+
+        folders = handler.getSubFoldersMatching("file2/", Pattern.compile("object"));
+        folderCount = 0;
+        while (folders.hasNext()){
+            String folderName = folders.next();
+            System.out.println(folderName);
+            folderCount++;
+        }
+        assertEquals(0,folderCount);
+    }
+
+
+    public void testGetSubFoldersMatchingAsStream() {
+        S3Handler handler = new S3Handler("testbucket", "us-east-1", 20);
+        handler.s3Client = testClient;
+
+        assertEquals(1,handler.getSubFoldersMatchingAsStream("file2/tile06/", Pattern.compile(".*")).count());
+
+        assertEquals(1,handler.getSubFoldersMatchingAsStream("file2/", Pattern.compile(".*05")).count());
+
+        assertEquals(0,handler.getSubFoldersMatchingAsStream("file2/", Pattern.compile("object")).count());
+    }
+}


### PR DESCRIPTION
…r than S3, can be supported in the future e.g. SMB and Azure Blob storage.

Summary of changes:
- Created the ITileStore interface to provide the abstraction.
- Modified the S3Handler class to support the ITileStore interface with changes to other parts of the code that were directly calling into its methods
- Moved cache handling code to another class to allow its use by other TileStore types
- Added unit tests for the S3Handler class